### PR TITLE
jQuery relicense, 2012 / was Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 |Project|Company|Original License|New License|Date of Change|URL|
 |:----|:----|:----|:----|:----|:----|
 |iText|iText|MPL-1.0|AGPL-3.0|2001/12/01|https://en.wikipedia.org/wiki/IText#Licensing|
+|jQuery|jQuery Foundation|MIT or GPL|MIT|2012/09/10|http://blog.jquery.com/2012/09/10/jquery-licensing-changes/|
 |Redis|Redis Labs|Apache-2.0|Commons Clause|2018/08/01|https://redis.com/legal/licenses|
 |MongoDB|MongoDB|AGPL-3.0|SSPL|2018/10/16|https://www.mongodb.com/press/mongodb-issues-new-server-side-public-license-for-mongodb-community-server|
 |Confluent|Confluent|Apache-2.0|Confluent Community License|2018/12/14|https://www.confluent.io/blog/license-changes-confluent-platform/|


### PR DESCRIPTION
Announcement of jQuery dropping dual license, no longer GPL, just MIT